### PR TITLE
画像パスの再設定

### DIFF
--- a/closet/src/main/java/com/example/SecurityConfiguration.java
+++ b/closet/src/main/java/com/example/SecurityConfiguration.java
@@ -15,7 +15,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
 	@Override
 	public void configure(WebSecurity web) throws Exception {//特定のリクエストだけセキュリティ設定を無視する条件をかける
-		web.ignoring().antMatchers("/webjars/**", "/css/**","/js/**");//webjarsやcssへのアクセスに対して、上記の機能が働く
+		web.ignoring().antMatchers("/webjars/**", "/css/**","/js/**", "/images/**");//webjarsやcssへのアクセスに対して、上記の機能が働く
 	}
 
 	@Override


### PR DESCRIPTION
アカウント作成画面の背景画像が反映されていなかったので、パスと通すために, "/images/**"を付け足した。